### PR TITLE
Change starup scripts to bash to support ACLs

### DIFF
--- a/assemblies/iwsn-assembly/src/main/assembly/bin/tr.iwsn-linux-x86-32
+++ b/assemblies/iwsn-assembly/src/main/assembly/bin/tr.iwsn-linux-x86-32
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 #
 # Copyright (c) 1999, 2010 Tanuki Software, Ltd.

--- a/assemblies/iwsn-assembly/src/main/assembly/bin/tr.iwsn-linux-x86-64
+++ b/assemblies/iwsn-assembly/src/main/assembly/bin/tr.iwsn-linux-x86-64
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 #
 # Copyright (c) 1999, 2010 Tanuki Software, Ltd.

--- a/assemblies/iwsn-federator-assembly/src/main/assembly/bin/tr.iwsn-federator-linux-x86-32
+++ b/assemblies/iwsn-federator-assembly/src/main/assembly/bin/tr.iwsn-federator-linux-x86-32
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 #
 # Copyright (c) 1999, 2010 Tanuki Software, Ltd.

--- a/assemblies/iwsn-federator-assembly/src/main/assembly/bin/tr.iwsn-federator-linux-x86-64
+++ b/assemblies/iwsn-federator-assembly/src/main/assembly/bin/tr.iwsn-federator-linux-x86-64
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 #
 # Copyright (c) 1999, 2010 Tanuki Software, Ltd.

--- a/assemblies/rs-assembly/src/main/assembly/bin/tr.rs-linux-x86-32
+++ b/assemblies/rs-assembly/src/main/assembly/bin/tr.rs-linux-x86-32
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 #
 # Copyright (c) 1999, 2010 Tanuki Software, Ltd.

--- a/assemblies/rs-assembly/src/main/assembly/bin/tr.rs-linux-x86-64
+++ b/assemblies/rs-assembly/src/main/assembly/bin/tr.rs-linux-x86-64
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 #
 # Copyright (c) 1999, 2010 Tanuki Software, Ltd.

--- a/assemblies/rs-federator-assembly/src/main/assembly/bin/tr.rs-federator-linux-x86-32
+++ b/assemblies/rs-federator-assembly/src/main/assembly/bin/tr.rs-federator-linux-x86-32
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 #
 # Copyright (c) 1999, 2010 Tanuki Software, Ltd.

--- a/assemblies/rs-federator-assembly/src/main/assembly/bin/tr.rs-federator-linux-x86-64
+++ b/assemblies/rs-federator-assembly/src/main/assembly/bin/tr.rs-federator-linux-x86-64
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 #
 # Copyright (c) 1999, 2010 Tanuki Software, Ltd.

--- a/assemblies/snaa-assembly/src/main/assembly/bin/tr.snaa-linux-x86-32
+++ b/assemblies/snaa-assembly/src/main/assembly/bin/tr.snaa-linux-x86-32
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 #
 # Copyright (c) 1999, 2010 Tanuki Software, Ltd.

--- a/assemblies/snaa-assembly/src/main/assembly/bin/tr.snaa-linux-x86-64
+++ b/assemblies/snaa-assembly/src/main/assembly/bin/tr.snaa-linux-x86-64
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 #
 # Copyright (c) 1999, 2010 Tanuki Software, Ltd.

--- a/assemblies/snaa-federator-assembly/src/main/assembly/bin/tr.snaa-federator-linux-x86-32
+++ b/assemblies/snaa-federator-assembly/src/main/assembly/bin/tr.snaa-federator-linux-x86-32
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 #
 # Copyright (c) 1999, 2010 Tanuki Software, Ltd.

--- a/assemblies/snaa-federator-assembly/src/main/assembly/bin/tr.snaa-federator-linux-x86-64
+++ b/assemblies/snaa-federator-assembly/src/main/assembly/bin/tr.snaa-federator-linux-x86-64
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 #
 # Copyright (c) 1999, 2010 Tanuki Software, Ltd.


### PR DESCRIPTION
Curently dash is teh default shell in most systems. In Pre-0.5.7 versions
Dash's builtin test does not support ACLs. Unfortunately 0.5.7 is sill not
packaged for most systems.

See: http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=556521
